### PR TITLE
only autoscroll if user is at the bottom of the chat

### DIFF
--- a/src/lib/Chat.svelte
+++ b/src/lib/Chat.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
 	import type { Chat } from '$misc/shared';
-	import { onDestroy } from 'svelte';
+	import { afterUpdate, beforeUpdate, onMount } from 'svelte';
 	import { ProgressRadial } from '@skeletonlabs/skeleton';
 	import snarkdown from 'snarkdown';
+	import { afterNavigate } from '$app/navigation';
 	import { chatStore, isLoadingAnswerStore, liveAnswerStore } from '$misc/stores';
-	import { scrollIntoView } from '$misc/actions';
 	import ChatMessages from './ChatMessages.svelte';
 
 	export let slug: string;
 	export let chat: Chat | undefined = undefined;
-
-	let anchor: HTMLElement;
 
 	$: if ($chatStore[slug]) {
 		// If this is used in the "Shared chat" view, the chat is not in the local store.
@@ -18,21 +16,32 @@
 		chat = $chatStore[slug];
 	}
 
-	const unsubscribe = liveAnswerStore.subscribe((answer) => {
-		if (answer.content) {
-			scrollIntoView(anchor);
-		}
+	// Autoscroll: https://svelte.dev/tutorial/update
+	let div: HTMLElement | null | undefined;
+	let autoscroll: boolean | null | undefined;
+
+	onMount(() => {
+		// bind to the *scrollable* element by it's id
+		// note: element is not exposed in this file, it lives in app.html
+		div = document.getElementById('page');
 	});
 
-	onDestroy(unsubscribe);
+	beforeUpdate(() => {
+		autoscroll = div && div.offsetHeight + div.scrollTop > div.scrollHeight - 20;
+	});
+
+	afterUpdate(() => {
+		if (autoscroll) div?.scrollTo({ top: div.scrollHeight, behavior: 'smooth' });
+	});
+
+	// autoscroll to bottom after navigation
+	afterNavigate(() => {
+		div?.scrollTo({ top: div.scrollHeight, behavior: 'smooth' });
+	});
 </script>
 
 {#if chat}
-	<div
-		id="chat"
-		class="flex flex-col container h-full mx-auto px-4 md:px-8"
-		style="justify-content: end"
-	>
+	<div class="flex flex-col container h-full mx-auto px-4 md:px-8" style="justify-content: end">
 		<slot name="additional-content-top" />
 
 		<div class="flex flex-col max-w-4xl md:mx-auto space-y-6 pt-6">
@@ -63,21 +72,5 @@
 				track="stroke-tertiary-500/30"
 			/>
 		</div>
-
-		<!-- element is used to scroll to the bottom of the page -->
-		<!-- the Svelte action lets the view autoscroll to bottom initially as soon as the anchor is rendered -->
-		<div id="anchor" use:scrollIntoView bind:this={anchor} />
 	</div>
 {/if}
-
-<style>
-	/* stay at the bottom of the page when messages are added */
-	#chat * {
-		overflow-anchor: none;
-	}
-
-	#anchor {
-		overflow-anchor: auto;
-		height: 1px;
-	}
-</style>

--- a/src/misc/actions.ts
+++ b/src/misc/actions.ts
@@ -1,6 +1,0 @@
-export function scrollIntoView(node: HTMLElement) {
-	// timeout needed because otherwise the rendered elements of this page have no height yet
-	setTimeout(() => {
-		node.scrollIntoView({ behavior: 'smooth' });
-	}, 100);
-}


### PR DESCRIPTION
closes #38 

Courtesy of the tutorial that keeps on giving. https://svelte.dev/tutorial/update

My intention is to only allow the user to "opt out" of the auto scroll when chatgpt is typing. Since I had to remove the anchor/action to do so, I made sure to reimplement the `scroll on navigation` behavior (in the `afterNavigate` lifecycle hook).
