### PR TITLE
Fix slow loading of larger conversations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Sorry folks, no semantic versioning, proper tagging or fancy automations yet. I'm just going to keep an old-sql manual changelog here for now.
 
+## April 28, 2023
+
+- improved performance in large chats by initializing the tokenizer only once (thanks @Schroedi)
+- minor bugfix: resize ChatInput on every input event (thanks @Schroedi)
+
 ## April 17, 2023
 
 - Opened but unclosed code tags in completions are now auto-closed automatically. This should make streaming (and partial) results more readable. Thanks to @Arro for the suggestion!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shipbit/slickgpt",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"license": "MIT",
 	"author": {
 		"name": "Simon Hopstätter",

--- a/src/misc/openai.ts
+++ b/src/misc/openai.ts
@@ -3,8 +3,11 @@ import type { Chat, ChatCost } from './shared';
 import GPT3Tokenizer from 'gpt3-tokenizer';
 import { ChatStorekeeper } from './chatStorekeeper';
 
-// initialization is slow, so only do it once
-const tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
+// Initialization is slow, so only do it once.
+// TypeScript misinterprets the export default class GPT3Tokenizer from gpt3-tokenizer
+// and throws "TypeError: GPT3Tokenizer is not a constructor" if we try to call the ctor here.
+// Therefore, we initialize the tokenizer in the first call to countTokens().
+let tokenizer: GPT3Tokenizer;
 
 export enum OpenAiModel {
 	Gpt35Turbo = 'gpt-3.5-turbo',
@@ -56,6 +59,11 @@ export const models: { [key in OpenAiModel]: OpenAiModelStats } = {
  * see https://github.com/syonfox/GPT-3-Encoder/issues/2
  */
 export function countTokens(message: ChatCompletionRequestMessage): number {
+	// see comment above
+	if (!tokenizer) {
+		tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
+	}
+
 	let num_tokens = 4; // every message follows <im_start>{role/name}\n{content}<im_end>\n
 	for (const [key, value] of Object.entries(message)) {
 		if (key !== 'name' && key !== 'role' && key !== 'content') {

--- a/src/misc/openai.ts
+++ b/src/misc/openai.ts
@@ -3,6 +3,9 @@ import type { Chat, ChatCost } from './shared';
 import GPT3Tokenizer from 'gpt3-tokenizer';
 import { ChatStorekeeper } from './chatStorekeeper';
 
+// initialization is slow, so only do it once
+const tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
+
 export enum OpenAiModel {
 	Gpt35Turbo = 'gpt-3.5-turbo',
 	Gpt4 = 'gpt-4',
@@ -53,8 +56,6 @@ export const models: { [key in OpenAiModel]: OpenAiModelStats } = {
  * see https://github.com/syonfox/GPT-3-Encoder/issues/2
  */
 export function countTokens(message: ChatCompletionRequestMessage): number {
-	const tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
-
 	let num_tokens = 4; // every message follows <im_start>{role/name}\n{content}<im_end>\n
 	for (const [key, value] of Object.entries(message)) {
 		if (key !== 'name' && key !== 'role' && key !== 'content') {


### PR DESCRIPTION
Initializing GPT3Tokenizer is pretty slow and was done for each message.

Edit: While it works when run with npm dev, if fails to compile: `TypeError: GPT3Tokenizer is not a constructor`. Maybe someone with more experience in TypeScript knows how to fix it.