### PR TITLE
57 FIREFOX: Height attribute on chatInput textarea compressing below 1 row size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Sorry folks, no semantic versioning, proper tagging or fancy automations yet. I'm just going to keep an old-sql manual changelog here for now.
 
+## July 03, 2023
+
+- Fixed an issue in Firefox that made the ChatInput appear too small in height
+
 ## May 12, 2023
 
 - add new enironment variable PUBLIC_DISABLE_TRACKING. Set this to `true` to prevent tracking actions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shipbit/slickgpt",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"license": "MIT",
 	"author": {
 		"name": "Simon Hopstätter",

--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -248,7 +248,7 @@
 					<div class="grid grid-cols-[1fr_auto]">
 						<!-- Input -->
 						<textarea
-							class="textarea overflow-hidden"
+							class="textarea overflow-hidden min-h-[42px]"
 							rows="1"
 							placeholder="Enter to send, Shift+Enter for newline"
 							use:textareaAutosizeAction


### PR DESCRIPTION
https://github.com/ShipBit/slickgpt/issues/57
