### PR TITLE
Main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ FIREBASE_STORAGEBUCKET=
 FIREBASE_MESSAGINGSENDERID=
 FIREBASE_APPID=
 PUBLIC_DISABLE_TRACKING=true
+# to test this out with the firebase bypass I just put junk in the empty ones above
+# modify the file as this pull shows: https://github.com/ShipBit/slickgpt/pull/78
+# then put your cloudflared token in
+SLICKGPT_CLOUDFLARED=cloudflared_token_goes_here

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# this specifically jsut runs the preview and 
+# it doesnt really expose port 3000 or 4173 here
+# Use the official Node.js 16 image as a parent image
+FROM node:16
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the package.json and package-lock.json (or yarn.lock) files
+COPY package*.json ./
+
+# Install any dependencies
+RUN npm install
+
+# Copy the rest of your app's source code
+COPY . .
+
+# Build the application for production
+RUN npm run build
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Define the command to run the app
+CMD ["npm", "run", "preview","--host"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.3"
+# update the .env file for all variables used!
+# cd dockers
+# docker build . -t slickgpt -t slickgpt:$(date +%Y%m%d)
+# docker compose -f docker-compose.slickgpt.yml build
+# docker-compose -f ./docker-compose.slickgpt.yml down
+# docker-compose -f ./docker-compose.slickgpt.yml pull
+# docker-compose -f ./docker-compose.slickgpt.yml up -d
+
+# docker compose --env-file ./slickgpt/slickgpt/.env -f ./slickgpt/slickgpt/docker-compose.slickgpt.yml up -d
+services:
+
+  slickgpt:
+    image: slickgpt:latest
+    build: .
+    command: npm run preview -- --host
+    # yes you are reading this right -- no ports exposed. 
+    # In your cloudflared configuration portal, you'll point the URL to
+    # http://slickgpt:4173
+
+  slicktunnel:
+    container_name: cloudflared-slick
+    image: cloudflare/cloudflared:latest #2023.5.1-amd64
+    restart: unless-stopped
+    command: tunnel run 
+    environment:
+      - TUNNEL_TOKEN=${SLICKGPT_CLOUDFLARED}
+    cap_drop:
+      - ALL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shipbit/slickgpt",
-	"version": "1.2.5",
+	"version": "1.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shipbit/slickgpt",
-			"version": "1.2.5",
+			"version": "1.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.5.3",


### PR DESCRIPTION
An answer for https://github.com/ShipBit/slickgpt/issues/23

These updates allow someone to dockerize and preview SlickGPT. My implementation uses cloudflared tunnel, but most people can probably take this and more easily test it out however else they wish.

Works very well, combined with https://github.com/ShipBit/slickgpt/pull/78 so that all the firebase stuff is bypassed