### PR TITLE
Fix tokens left example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shipbit/slickgpt",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shipbit/slickgpt",
-			"version": "1.5.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/msal-browser": "^3.10.0",

--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -65,7 +65,7 @@
 	let tokensLeft = -1;
 	$: {
 		tokensLeft = chatCost
-			? chatCost.maxTokensForModel - (chatCost.tokensTotal + messageTokens)
+			? models[chat.settings.model].contextWindow - (chatCost.tokensTotal + messageTokens)
 			: -1;
 	}
 	$: maxTokensCompletion = chat.settings.max_tokens;

--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -65,7 +65,7 @@
 	let tokensLeft = -1;
 	$: {
 		tokensLeft = chatCost
-			? models[chat.settings.model].contextWindow - (chatCost.tokensTotal + messageTokens)
+			? chatCost.maxTokensForModel - (chatCost.tokensTotal + messageTokens)
 			: -1;
 	}
 	$: maxTokensCompletion = chat.settings.max_tokens;

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -38,6 +38,8 @@
 	</div>
 
 	<div class="flex gap-2">
+		<a href="/legal">Warning: not official slickgpt</a>
+		<span>|</span>
 		<a href="/legal">Legal</a>
 		<span>|</span>
 		<!-- Copyrights -->
@@ -47,7 +49,7 @@
 			target="_blank"
 			rel="noreferrer"
 		>
-			<span class="hidden md:inline">made with</span>
+			<span class="hidden md:inline">Originally made with</span>
 			<img src="/shipbit-logo.svg" class="w-5 h-5" alt="ShipBit Logo" />
 			<span class="hidden md:inline">by</span>
 			<span class="font-bold md:text-shipbit font-barlow">ShipBit</span>

--- a/src/lib/Modals/SettingsModal.svelte
+++ b/src/lib/Modals/SettingsModal.svelte
@@ -49,7 +49,7 @@
 	let editApiKey = false;
 
 	$: {
-		maxTokensForModel = models[$chatStore[slug].settings.model].maxTokens;
+		maxTokensForModel = models[$chatStore[slug].settings.model].maxTokens; //Now: max reply length
 		settings.max_tokens = clamp(settings.max_tokens, 0, maxTokensForModel);
 	}
 </script>


### PR DESCRIPTION
[**Do not** directly merge, it contains my diverged modification]

The [tokens left] part shown at the left bottom of the chat session is not correct. Simply changing `OpenAiModelStats.maxTokens` will and will not work.

- Will work: it indeed corrects the [Tokens left] number;
- Will not work: it breaks the settings -> advanced -> maxTokens upper limit and makes it really hard to locate precise settings < 4096 (models reply tokens) with mice dragging.

The issue comes from multiplexing of the concept "max tokens that a model can reply (often 4096 now)" and "the max context tokens applicable by a model (16k, 128k, ~~and even 200k (claude)~~)".

This commit aims at splitting them.