### PR TITLE
Add piechart part

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shipbit/slickgpt",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shipbit/slickgpt",
-			"version": "1.5.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@azure/msal-browser": "^3.10.0",

--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -65,7 +65,7 @@
 	let tokensLeft = -1;
 	$: {
 		tokensLeft = chatCost
-			? chatCost.maxTokensForModel - (chatCost.tokensTotal + messageTokens)
+			? models[chat.settings.model].contextWindow - (chatCost.tokensTotal + messageTokens)
 			: -1;
 	}
 	$: maxTokensCompletion = chat.settings.max_tokens;

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -38,6 +38,8 @@
 	</div>
 
 	<div class="flex gap-2">
+		<a href="/legal">Warning: not official slickgpt</a>
+		<span>|</span>
 		<a href="/legal">Legal</a>
 		<span>|</span>
 		<!-- Copyrights -->
@@ -47,7 +49,7 @@
 			target="_blank"
 			rel="noreferrer"
 		>
-			<span class="hidden md:inline">made with</span>
+			<span class="hidden md:inline">Originally made with</span>
 			<img src="/shipbit-logo.svg" class="w-5 h-5" alt="ShipBit Logo" />
 			<span class="hidden md:inline">by</span>
 			<span class="font-bold md:text-shipbit font-barlow">ShipBit</span>

--- a/src/lib/Modals/CostModal.svelte
+++ b/src/lib/Modals/CostModal.svelte
@@ -19,6 +19,8 @@
 	const tokensCompletionPercent = Math.round((tokensCompletion / maxTokensForModel) * 100);
 	const tokensPromptPercent = Math.round((tokensPrompt / maxTokensForModel) * 100);
 	const maxCompletionLeftPercent = Math.round((maxCompletionLeft / maxTokensForModel) * 100);
+	const minSpareContextPercent = Math.round((maxTokensForModel - messageTokens - tokensCompletion
+	- tokensPrompt - maxCompletionLeft) / maxTokensForModel * 100);
 
 	const conicStops: ConicStop[] = [
 		{
@@ -43,8 +45,14 @@
 			label: `Next completion (max. ${maxCompletionLeft})`,
 			color: 'rgb(var(--color-success-500))',
 			start: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent,
-			end: Math.max(maxCompletionLeftPercent, 100)
-		}
+			end: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent
+		},
+		{
+			label: `Spare Context (min. ${maxCompletionLeft})`,
+			color: 'rgb(var(--color-surface-300))',
+			start: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent,
+			end: Math.max(minSpareContextPercent, 100)
+		},
 	];
 
 	function handleClose() {

--- a/src/lib/Modals/CostModal.svelte
+++ b/src/lib/Modals/CostModal.svelte
@@ -14,6 +14,10 @@
 		maxTokensForModel - tokensPrompt - tokensCompletion - messageTokens,
 		maxTokensCompletion
 	);
+	const minSpareContextLeft = Math.max(
+		maxTokensForModel - tokensPrompt - tokensCompletion - messageTokens - maxCompletionLeft,
+		0
+	);
 
 	const messageTokensPercent = Math.round((messageTokens / maxTokensForModel) * 100);
 	const tokensCompletionPercent = Math.round((tokensCompletion / maxTokensForModel) * 100);
@@ -48,7 +52,7 @@
 			end: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent
 		},
 		{
-			label: `Spare Context (min. ${maxCompletionLeft})`,
+			label: `Spare Context (min. ${minSpareContextLeft})`,
 			color: 'rgb(var(--color-surface-300))',
 			start: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent,
 			end: Math.max(minSpareContextPercent, 100)

--- a/src/lib/Modals/SettingsModal.svelte
+++ b/src/lib/Modals/SettingsModal.svelte
@@ -49,7 +49,7 @@
 	let editApiKey = false;
 
 	$: {
-		maxTokensForModel = models[$chatStore[slug].settings.model].maxTokens;
+		maxTokensForModel = models[$chatStore[slug].settings.model].maxTokens; //Now: max reply length
 		settings.max_tokens = clamp(settings.max_tokens, 0, maxTokensForModel);
 	}
 </script>


### PR DESCRIPTION
The original pie chart shows only the distribution among used and to-be-used tokens. 

We add a unused (spare) tokens part, to give users a clear view of their context usage and remaining dialogue spaces.

Example pie chart below:

![image](https://github.com/ShipBit/slickgpt/assets/16047865/8b20fc49-0e85-4560-a4b1-242fcfac13b5)