### PR TITLE
Enhance Token Visualization with "Spare Context Window" part in Piechart

### DIFF
--- a/src/lib/Modals/CostModal.svelte
+++ b/src/lib/Modals/CostModal.svelte
@@ -14,11 +14,17 @@
 		maxTokensForModel - tokensPrompt - tokensCompletion - messageTokens,
 		maxTokensCompletion
 	);
+	const minSpareContextLeft = Math.max(
+		maxTokensForModel - tokensPrompt - tokensCompletion - messageTokens - maxCompletionLeft,
+		0
+	);
 
 	const messageTokensPercent = Math.round((messageTokens / maxTokensForModel) * 100);
 	const tokensCompletionPercent = Math.round((tokensCompletion / maxTokensForModel) * 100);
 	const tokensPromptPercent = Math.round((tokensPrompt / maxTokensForModel) * 100);
 	const maxCompletionLeftPercent = Math.round((maxCompletionLeft / maxTokensForModel) * 100);
+	const minSpareContextPercent = Math.round((maxTokensForModel - messageTokens - tokensCompletion
+	- tokensPrompt - maxCompletionLeft) / maxTokensForModel * 100);
 
 	const conicStops: ConicStop[] = [
 		{
@@ -43,8 +49,14 @@
 			label: `Next completion (max. ${maxCompletionLeft})`,
 			color: 'rgb(var(--color-success-500))',
 			start: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent,
-			end: Math.max(maxCompletionLeftPercent, 100)
-		}
+			end: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent
+		},
+		{
+			label: `Spare Context (min. ${minSpareContextLeft})`,
+			color: 'rgb(var(--color-surface-300))',
+			start: tokensPromptPercent + tokensCompletionPercent + messageTokensPercent + maxCompletionLeftPercent,
+			end: Math.max(minSpareContextPercent, 100)
+		},
 	];
 
 	function handleClose() {


### PR DESCRIPTION
Previously, the piechart displayed only the tokens used and those allocated for upcoming prompts and completions. 

This update aims to provide a more comprehensive overview by including the "Spare Context Window."