### PR TITLE
bugfix: error loading chats with a deleted model

### DIFF
--- a/src/misc/openai.ts
+++ b/src/misc/openai.ts
@@ -162,6 +162,10 @@ export function countTokens(message: ChatMessage): number {
 	return num_tokens;
 }
 
+export function modelExists(modelName: OpenAiModel): boolean {
+	return modelName in models;
+}
+
 export function estimateChatCost(chat: Chat): ChatCost {
 	let tokensPrompt = 0;
 	let tokensCompletion = 0;


### PR DESCRIPTION
    [generated by claude-3-opus using slick-zy-gpt fork]
    When a model is deleted from SlickGPT, attempting to load existing
    chats that used the deleted model would result in an error. This is
    because the code assumes the model object always exists.

    This commit adds a check to see if the model for a chat still exists
    when loading it. If the model is gone, it will:

    1. Show a warning toast to the user explaining the model was deleted
    and that we are falling back to the default model.

![image](https://github.com/ShipBit/slickgpt/assets/16047865/c1ea7470-f433-4ae6-acfc-9f0d1106e9a4)

    (The model name is experimental)

    2. Set the chat's model to the default model specified in
    `defaultOpenAiSettings`. This allows the chat to still load and
    be usable.

    This could be a temporary fix to prevent errors and data loss.

