### PR TITLE
Fix: Prevent submission on Enter key in empty/whitespace textarea

### DIFF
--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -249,13 +249,13 @@
 			if ($settingsStore.useTitleSuggestions 
 			   && !hasUpdatedChatTitle 
 			   && firstUserPrompt) {
-                hasUpdatedChatTitle = true; // Ensure the title is only updated once
-                const title = await suggestChatTitle({
-                    ...chat,
-                    messages: [...chat.messages, { role: 'user', content: firstUserPrompt }]
-                });
-                chatStore.updateChat(slug, { title });
-            }
+				hasUpdatedChatTitle = true; // Ensure the title is only updated once
+				const title = await suggestChatTitle({
+					...chat,
+					messages: [...chat.messages, { role: 'user', content: firstUserPrompt }]
+				});
+				chatStore.updateChat(slug, { title });
+			}
 		} catch (err) {
 			handleError(err);
 		}
@@ -312,6 +312,14 @@
 		rawAnswer = '';
 	}
 
+	async function addNewLineAndResize() {
+		input += '\n';
+
+		// tick is required for the action to resize the textarea
+		await tick();
+		textareaAutosizeAction(textarea);
+	}
+
 	function handleKeyDown(event: KeyboardEvent) {
 		clearTimeout(debounceTimer);
 		debounceTimer = window.setTimeout(calculateMessageTokens, 750);
@@ -321,7 +329,12 @@
 		}
 
 		if (event.key === 'Enter' && !event.shiftKey) {
-			handleSubmit();
+			if (input.trim() === '') {
+				// Create new line if input is whitespaced.
+				addNewLineAndResize();
+			} else {
+				handleSubmit();
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes
This PR modifies the behavior of the `textarea` to prevent form submissions when pressing the Enter key if the input is empty or contains only whitespace. Instead, in these cases, pressing Enter will add a new line.

### Related Issue
Fixes #113 

### Approach
- Added an async helper function `addNewLineAndResize` to handle adding new lines and resizing the `textarea`.
- Updated `handleKeyDown` to call this new function when the input is empty or contains only whitespace.