### PR TITLE
Fix keylistener handling, resolve race condition, and correct delete chat functionality

### DIFF
--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -120,9 +120,12 @@
 
 	// Variable to keep track of the user's first prompt
 	let firstUserPrompt = '';
-	let hasUpdatedChatTitle = false; // Flag to avoid multiple updates
+	// Flag to avoid multiple updates
+	let hasUpdatedChatTitle = false;
 
 	async function handleSubmit() {
+		if (input.trim() === '') return;
+
 		isLoadingAnswerStore.set(true);
 		inputCopy = input;
 
@@ -246,9 +249,7 @@
 					addCompletionToChat();
 				}
 			}
-			if ($settingsStore.useTitleSuggestions 
-			   && !hasUpdatedChatTitle 
-			   && firstUserPrompt) {
+			if ($settingsStore.useTitleSuggestions && !hasUpdatedChatTitle && firstUserPrompt) {
 				hasUpdatedChatTitle = true; // Ensure the title is only updated once
 				const title = await suggestChatTitle({
 					...chat,
@@ -279,7 +280,7 @@
 
 		const data = JSON.parse(event.data);
 
-		showToast(toastStore, data.message || 'An error occured.', 'error');
+		showToast(toastStore, data.message || 'An error occurred.', 'error');
 
 		if (data.message.includes('API key')) {
 			showModalComponent(modalStore, 'SettingsModal', { slug });
@@ -328,13 +329,21 @@
 			return;
 		}
 
-		if (event.key === 'Enter' && !event.shiftKey) {
-			if (input.trim() === '') {
-				// Create new line if input is whitespaced.
-				addNewLineAndResize();
-			} else {
-				handleSubmit();
-			}
+		switch (event.key) {
+			case 'ArrowUp':
+			case 'ArrowDown':
+				event.stopImmediatePropagation();
+				break;
+			case 'Enter':
+				if (!event.shiftKey) {
+					if (input.trim() === '') {
+						// Create a new line if input is whitespace.
+						addNewLineAndResize();
+					} else {
+						handleSubmit();
+					}
+				}
+				break;
 		}
 	}
 

--- a/src/misc/eventSource.ts
+++ b/src/misc/eventSource.ts
@@ -2,14 +2,14 @@ import { SSE } from 'sse.js';
 
 export class EventSource {
 	private eventSource?: SSE;
-	private handleAnswer?: (event: MessageEvent<any>) => void;
+	private handleAnswer?: (event: MessageEvent<any>) => Promise<void>;
 	private handleError?: (event: MessageEvent<any>) => void;
 	private handleAbort?: (event: MessageEvent<any>) => void;
 
 	start(
 		url: string,
 		payload: any,
-		handleAnswer: (event: MessageEvent<any>) => void,
+		handleAnswer: (event: MessageEvent<any>) => Promise<void>,
 		handleError: (event: MessageEvent<any>) => void,
 		handleAbort: (event: MessageEvent<any>) => void,
 		token?: string

--- a/src/misc/openai.ts
+++ b/src/misc/openai.ts
@@ -186,12 +186,7 @@ export function estimateChatCost(chat: Chat): ChatCost {
 }
 
 export function getProviderForModel(model: AiModel): AiProvider {
-	if (model.includes('llama')) {
-		return AiProvider.Meta;
-	} else if (model.includes('mistral')) {
-		return AiProvider.Mistral;
-	}
-	return AiProvider.OpenAi;
+	return model ? models[model].provider : AiProvider.OpenAi;
 }
 
 export function getDefaultModelForProvider(provider: AiProvider): AiModel {


### PR DESCRIPTION
### Summary
This PR addresses the following issues:
1. **Keylistener Issue**: Prevents the default action that blocks the arrow keys' movement within the textarea.
2. **Race Condition**: Fixes a race condition introduced in #111 that could disrupt normal operations.
3. **Delete Chat Bug**: Corrects the delete chat functionality, resolving a bug introduced in #112.

### Background
1. **Keylistener Issue**: The `svelte-command-palette` library stops the propagation of arrow keys by calling `preventDefault`. This workaround adjusts the keylistener logic to allow arrow key navigation within the textarea. More details can be found in the issue posted here: https://github.com/rohitpotato/svelte-command-palette/issues/16.
2. **Race Condition**: The race condition was inadvertently introduced in #111 by not properly handling asynchronous operations. This has been resolved by ensuring proper sequencing and handling of async tasks.
3. **Delete Chat Bug**: The bug in the delete chat functionality was introduced in #112. It was caused by a function `getProviderForModel` returning `undefined` before checking if the model is `undefined`. The function now ensures proper checks to avoid this issue.

### Changes
- Modified keylistener logic to allow arrow key navigation in the textarea.
- Resolved the race condition by ensuring proper asynchronous handling.
- Fixed the delete chat logic to function correctly without errors.

### Related PRs
- Bug in the race condition: PR #111 
- Introduced delete chat bug: PR #112 

### Issue References
- Fixes #115

### Testing
- [x] Arrow keys function correctly in the textarea.
- [x] The application works without race conditions.
- [x] Chat deletion operates as expected across various scenarios.