### PR TITLE
Sanitize chat title by removing double quotes

### DIFF
--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -254,8 +254,8 @@
 				const title = await suggestChatTitle({
 					...chat,
 					messages: [...chat.messages, { role: 'user', content: firstUserPrompt }]
-				});
-				chatStore.updateChat(slug, { title });
+				})
+				chatStore.updateChat(slug, { title: title.replaceAll('"', '') });
 			}
 		} catch (err) {
 			handleError(err);


### PR DESCRIPTION
## Description
This PR sanitizes chat titles by removing any double quotes, ensuring cleaner and more consistent titles.

## Changes
- Replaces double quotes in chat titles with empty strings.

## Related Issues
Closes #108 

## Checklist
- [X] Code follows the style guidelines of this project.
- [X] Code has been self-reviewed.
- [X] Changes generate no new warnings.