### PR TITLE
fix (pro): incorrect migration of auth keys causing slow login

### DIFF
--- a/src/misc/storageService.ts
+++ b/src/misc/storageService.ts
@@ -82,15 +82,19 @@ class IdbStorageService implements StorageService {
 
 	async migrateLocalStorageToIndexedDB() {
 		const keys = Object.keys(localStorage);
-		for (const key of keys) {
-			if (key.includes('mode')) continue; // skip theme settings
 
+		const authSubstrings = ['msal.', 'mode', 'shipbit']; // don't migrate these
+
+		for (const key of keys) {
 			const value = localStorage.getItem(key);
 			if (value) {
 				try {
-					const parsedValue = JSON.parse(value);
-					await this.setItem(key, parsedValue);
-					localStorage.removeItem(key);
+					const isAuthKey = authSubstrings.some(substring => key.includes(substring));
+					if (!isAuthKey) {
+						const parsedValue = JSON.parse(value);
+						await this.setItem(key, parsedValue);
+						localStorage.removeItem(key);
+					}
 				} catch (e) {
 					console.error(`Failed to migrate key "${key}"`, e);
 				}


### PR DESCRIPTION
fixes bug where the auth keys are migrated to indexeddb too causing it to reset them hence leading to a longer loading time for pro users.