### PR TITLE
fix: prevent auto-title updates for legacy chats

### DIFF
--- a/src/lib/ChatInput.svelte
+++ b/src/lib/ChatInput.svelte
@@ -52,7 +52,6 @@
 	let lastUserMessage: ChatMessage | null = null;
 	let currentMessages: ChatMessage[] | null = null;
 
-	let hasUpdatedChatTitle = false;
 	let isEditMode = false;
 	let originalMessage: ChatMessage | null = null;
 	let isDraggingFile = false;
@@ -243,10 +242,9 @@
 
 			if (
 				$settingsStore.useTitleSuggestions &&
-				!hasUpdatedChatTitle &&
-				chat.hasUpdatedChatTitle !== true
+				chat.hasUpdatedChatTitle === false &&
+				input.trim()
 			) {
-				hasUpdatedChatTitle = true;
 				const title = await suggestChatTitle({
 					...chat,
 					messages: [...chat.messages, { role: 'user', content: input.trim() }]


### PR DESCRIPTION
Old chats prior to 764a937a58fc4956962c50bf73dd30ff0da9bea9 may have their titles mistakenly auto-updated when users continue these chats in newer slickgpt versions. To fix this, I:


    - Changed condition from `!== true` to `=== false` for hasUpdatedChatTitle check
    - This ensures legacy chats (where hasUpdatedChatTitle is undefined) won't trigger automatic title updates
    - Only new chats with explicit hasUpdatedChatTitle: false will trigger the auto-update feature

BREAKING CHANGE: Auto-title behavior changed for legacy chats